### PR TITLE
Simplify publisher type by embedding channel paramter in Bus trait/

### DIFF
--- a/src/chan/direct.rs
+++ b/src/chan/direct.rs
@@ -63,9 +63,7 @@ impl DirectChannel {
     /// Create a new [Publisher] that allows for publishing on the [DirectBus]
     pub fn publisher<B: DirectBus<Chan = DirectChannel>>(&self) -> Publisher<B> {
         debug!("Created publisher for direct bus {}", type_name::<B>());
-        Publisher {
-            chan: self.clone(),
-        }
+        Publisher { chan: self.clone() }
     }
 }
 

--- a/src/chan/mod.rs
+++ b/src/chan/mod.rs
@@ -22,6 +22,8 @@ pub use topic::*;
 
 /// A Bus. Base trait for several other buses
 pub trait Bus: Unpin {
+    /// The [Channel] this bus is associated with.
+    type Chan: Channel;
     /// The type of payload of the messages that are published on or consumed from it.
     type PublishPayload;
 }
@@ -72,14 +74,13 @@ where
 /// of the [Bus::PublishPayload] type. [Publisher]s take care
 /// of serializing the payloads before publishing.
 #[derive(Clone)]
-pub struct Publisher<C, B> {
-    chan: C,
-    _marker: PhantomData<B>,
+pub struct Publisher<B: Bus> {
+    chan: B::Chan,
 }
 
-impl<C, B> Publisher<C, B>
+impl<B> Publisher<B>
 where
-    C: Channel,
+    B: Bus,
 {
     async fn publish_with_properties<'p, P>(
         &self,
@@ -110,9 +111,12 @@ pub use tests::*;
 
 #[cfg(test)]
 mod tests {
+    use async_trait::async_trait;
+    use lapin::BasicProperties;
     use serde::{Deserialize, Serialize};
+    use uuid::Uuid;
 
-    use crate::bus;
+    use crate::{bus, bus_impl, Channel, Never};
 
     pub const RABBIT_MQ_URL: &str = "amqp://tg:secret@localhost:5673";
 
@@ -121,22 +125,44 @@ mod tests {
         pub message: String,
     }
 
-    bus!("A frame bus", FrameBus, FramePayload);
+    #[async_trait]
+    impl Channel for Never {
+        async fn publish_with_properties(
+            &self,
+            _payload_bytes: &[u8],
+            _routing_key: &str,
+            _properties: BasicProperties,
+            _correlation_uuid: Uuid,
+            _reply_uuid: Option<Uuid>,
+        ) -> crate::Result<()> {
+            unreachable!()
+        }
+    }
+
+    bus!("A frame bus", FrameBus);
+    bus_impl!(FrameBus, Never, FramePayload);
 }
 
 #[doc(hidden)]
 #[macro_export]
 macro_rules! bus {
-    ($doc:literal, $name:ident, $publish_payload:ty) => {
+    ($doc:literal, $bus:ident) => {
         #[doc = $doc]
         #[derive(Clone, Copy, Debug)]
-        pub enum $name {}
+        pub enum $bus {}
+    };
+    ($bus:ident) => {
+        $crate::bus!("", $bus);
+    };
+}
 
-        impl $crate::Bus for $name {
+#[doc(hidden)]
+#[macro_export]
+macro_rules! bus_impl {
+    ($bus:ident, $chan:ty, $publish_payload:ty) => {
+        impl $crate::Bus for $bus {
+            type Chan = $chan;
             type PublishPayload = $publish_payload;
         }
-    };
-    ($name:ident, $publish_payload:ty) => {
-        $crate::bus!("", $name, $publish_payload);
     };
 }

--- a/src/chan/mod.rs
+++ b/src/chan/mod.rs
@@ -20,7 +20,14 @@ pub use rpc::*;
 #[cfg(feature = "topic")]
 pub use topic::*;
 
-/// A Bus. Base trait for several other buses
+/// A Bus. Base trait for several other buses.
+/// This trait is best implemented by using one of the `*_bus!` macros
+/// this crate provices.
+/// *If you are going to implement this trait manually, make sure you associate
+/// the correct [Channel] type to [Bus::Chan]:*
+/// - For [DirectBus], use [DirectChannel],
+/// - For [TopicBus], use [TopicChannel],
+/// - For [RpcBus] and [RpcCommBus], use [RpcCommBus].
 pub trait Bus: Unpin {
     /// The [Channel] this bus is associated with.
     type Chan: Channel;

--- a/src/chan/rpc/comm.rs
+++ b/src/chan/rpc/comm.rs
@@ -321,7 +321,7 @@ macro_rules! rpc_comm_bus {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! rpc_comm_bus_impl {
-    ($bus:ty, $back_payload:ty, $initial_payload:ty, $forth_payload:ty, $args:ty, $queue:expr) => {
+    ($bus:ty, $initial_payload:ty, $back_payload:ty, $forth_payload:ty, $args:ty, $queue:expr) => {
         impl $crate::RpcCommBus for $bus {
             type InitialPayload = $initial_payload;
             type BackPayload = $back_payload;

--- a/src/chan/rpc/comm.rs
+++ b/src/chan/rpc/comm.rs
@@ -125,9 +125,7 @@ impl RpcChannel {
     /// Setup a new [Publisher] associated wit the [RpcCommBus].
     pub fn comm_publisher<B: RpcCommBus>(&self) -> Publisher<B> {
         debug!("Created comm publisher for RPC bus {}", type_name::<B>());
-        Publisher {
-            chan: self.clone(),
-        }
+        Publisher { chan: self.clone() }
     }
 }
 
@@ -282,7 +280,14 @@ macro_rules! rpc_comm_bus {
         #[derive(Clone, Copy, Debug)]
         pub enum $bus {}
 
-        $crate::rpc_comm_bus_impl!($bus, $initial_payload, $back_payload, $forth_payload, $args, $queue);
+        $crate::rpc_comm_bus_impl!(
+            $bus,
+            $initial_payload,
+            $back_payload,
+            $forth_payload,
+            $args,
+            $queue
+        );
     };
     (doc = $doc:literal, bus = $bus:ident, initial = $initial_payload:ty, back = $back_payload:ty, forth = $forth_payload:ty, args = $args:ty, queue = $queue:expr) => {
         $crate::rpc_comm_bus!(

--- a/src/chan/rpc/mod.rs
+++ b/src/chan/rpc/mod.rs
@@ -180,9 +180,7 @@ impl RpcChannel {
     /// Create a new [Publisher] that allows for publishing on the [RpcBus]
     pub fn publisher<B: RpcBus<Chan = Self>>(&self) -> Publisher<B> {
         debug!("Created publisher for RPC bus {}", type_name::<B>());
-        Publisher {
-            chan: self.clone(),
-        }
+        Publisher { chan: self.clone() }
     }
 }
 

--- a/src/chan/topic.rs
+++ b/src/chan/topic.rs
@@ -434,7 +434,7 @@ macro_rules! topic_bus {
     ($doc:literal, $bus:ident, $publish_payload:ty, $exchange:ty, $topic:literal) => {
         $crate::bus!($doc, $bus);
 
-        $crate::bus_impl!($bus, TopicChannel<$exchange>, $publish_payload);
+        $crate::bus_impl!($bus, $crate::TopicChannel<$exchange>, $publish_payload);
 
         $crate::topic_bus_impl!($bus, $exchange, $topic);
     };

--- a/src/chan/topic.rs
+++ b/src/chan/topic.rs
@@ -103,9 +103,7 @@ impl<E: TopicExchange> TopicChannel<E> {
     /// Create a new [Publisher] that publishes onto the [TopicBus].
     pub fn publisher<B: TopicBus<Chan = Self>>(&self) -> Publisher<B> {
         debug!("Created publisher for topic bus {}", type_name::<B>());
-        Publisher {
-            chan: self.clone(),
-        }
+        Publisher { chan: self.clone() }
     }
 }
 
@@ -137,7 +135,7 @@ impl<E: TopicExchange> Channel for TopicChannel<E> {
     }
 }
 
-impl<'p, B> Publisher< B>
+impl<'p, B> Publisher<B>
 where
     B: TopicBus,
     B::PublishPayload: Deserialize<'p> + Serialize,


### PR DESCRIPTION
Open question: can a user implement `Bus` with an incorrect `Channel`? If so, how can this be avoided?